### PR TITLE
switch epub source to mathml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ html: $(html_js) $(html_media) $(html_files)
 # epub rules
 build/epub/intermediate.epub: $(metadata) $(css) $(markdown)
 	@mkdir -p $(@D)
-	pandoc --write=epub3 --output=$@ --smart --mathjax --epub-stylesheet=$(css) $(metadata) $(markdown)
+	pandoc --write=epub3 --output=$@ --smart --mathml --epub-stylesheet=$(css) $(metadata) $(markdown)
 
 build/epub/output.epub: build/epub/intermediate.epub MathJax $(includes) $(javascript) utils/post-process-epub.py
 	python utils/post-process-epub.py --output=$@ --input=$< --include-in-headers=$(includes) --mathjax=MathJax $(javascript)

--- a/src/lecture-17.md
+++ b/src/lecture-17.md
@@ -163,7 +163,7 @@ waving a notebook in the air. She calls you over and says:
 "For any function $f(x,y)$ of the form $f(x,y)=g(x)h(y)$ and any
 rectangle $R=[a,b]\times[c,d]$, I know that
 
-$$\iint_Rf(x,y)dxdy=\left(\int_a^bg(x)dx\right)\cdot\left(\int_c^dh(y)dy\right)."$$
+$$\iint_Rf(x,y)dxdy=\left(\int_a^bg(x)dx\right)\cdot\left(\int_c^dh(y)dy\right).\text{"}$$
 
 Is she right?
 
@@ -230,7 +230,7 @@ notebook in the air. She called you over and said:
 "For any function $f(x,y)$ of the form $f(x,y)=g(x)h(y)$ and any
 rectangle $R=[a,b]\times[c,d]$, I know that
 
-$$\iint_Rf(x,y)dxdy=\left(\int_a^bg(x)dx\right)\cdot\left(\int_c^dh(y)dy\right)."$$
+$$\iint_Rf(x,y)dxdy=\left(\int_a^bg(x)dx\right)\cdot\left(\int_c^dh(y)dy\right).\text{"}$$
 
 Was she right?
 

--- a/utils/post-process-epub.py
+++ b/utils/post-process-epub.py
@@ -30,22 +30,13 @@ MATHJAX_CONFIG = r'''
 //<![CDATA[
 MathJax.Hub.Config({
     jax: [
-        "input/TeX",
+        "input/MathML",
         "output/SVG",
     ],
     extensions: [
-        "tex2jax.js",
+        "mml2jax.js",
         "MathEvents.js",
     ],
-    TeX: {
-        extensions: [
-            "AMSmath.js",
-            "AMSsymbols.js",
-            "noErrors.js",
-            "noUndefined.js",
-            "autoload-all.js"
-        ]
-    },
     MathMenu: {
         showRenderer: false
     },
@@ -62,7 +53,9 @@ MATHJAX_FILES = (
         'MathJax.js',
         'images',
         'jax/element',
-        'jax/input/TeX',
+        'jax/input/MathML',
+#        'jax/input/TeX',
+#        'extensions/MathML',
         'jax/output/SVG/autoload',
         'jax/output/SVG/config.js',
         'jax/output/SVG/fonts/TeX',
@@ -73,11 +66,15 @@ MATHJAX_FILES = (
         'extensions/MathEvents.js',
         'extensions/MathMenu.js',
         'extensions/MathZoom.js',
-        'extensions/tex2jax.js',
+        'extensions/mml2jax.js',
+#        'extensions/tex2jax.js',
         )
 
 EPUB_URI = 'http://www.idpf.org/2007/opf'
 XHTML_URI = 'http://www.w3.org/1999/xhtml'
+MATHML_URI = 'http://www.w3.org/1998/Math/MathML'
+
+URI_REGEX = re.compile(r'^{(.*)}')
 
 CHAPTER_REGEX = re.compile(r'ch\d+\.xhtml')
 
@@ -125,6 +122,14 @@ class EpubUpdater:
         ElementTree.register_namespace('', uri)
         if uri == XHTML_URI:
             ElementTree.register_namespace('epub', EPUB_URI)
+            for elem in xmltree.getiterator():
+                match = URI_REGEX.match(elem.tag)
+                if match is None:
+                    continue
+                uri = match.group(1)
+                if uri != XHTML_URI:
+                    elem.tag = URI_REGEX.sub('{%s}'%XHTML_URI, elem.tag)
+                    elem.set('xmlns', uri)
 
         # as far as I can tell you have to dump to a file to get the
         # xml_declaration, so we use BytesIO to emulate a file


### PR DESCRIPTION
this might be a bit more limited in the long run,
however we are not using any tex functionality that
can't be done in mathml at the moment and by using
mathml we don't have to modify pandoc

in the future it should just be a few lines change to
switch back if need be
